### PR TITLE
Fix: Correctly parse CSV headers when problematic first line is present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3501,6 +3501,25 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",

--- a/src/services/googleSheets.ts
+++ b/src/services/googleSheets.ts
@@ -421,10 +421,12 @@ export const getSubmissions = async (sheetId: string = TEST_SHEET_ID, useLocalTe
         let papaParseConfig: any; // Using any for papaParseConfig
 
         if (isProblematicFirstLine) {
+            // csvStringToParse already has the problematic first line removed.
+            // Now, parse it by reading headers from the *new* first line.
             papaParseConfig = {
                 ...commonConfigBase,
-                header: false,
-                columns: transformedCorrectHeaders,
+                header: true, // Read headers from the (new) first line
+                transformHeader: papaParseTransformHeaderOption, // Use the existing header transformation
             };
         } else {
             papaParseConfig = {


### PR DESCRIPTION
The previous logic for handling a malformed first line in the submissions CSV (where the first line contained Spotify URIs instead of headers) was still attempting to use a predefined set of headers. This caused a mismatch because the line *after* the problematic URI line actually contained the correct headers.

This commit modifies the `getSubmissions` function in `src/services/googleSheets.ts`:
- When the problematic first line (Spotify URIs) is detected and removed, PapaParse is now configured with `header: true`.
- This allows it to correctly read the actual headers from the subsequent line of the CSV.
- The standard `transformHeader` function is applied to these dynamically read headers.

This change ensures that submission data is correctly mapped to its corresponding fields, resolving issues where votes and submission data were not populating correctly.