### PR TITLE
Fix: Resolve build error by removing unused variables

### DIFF
--- a/src/services/googleSheets.ts
+++ b/src/services/googleSheets.ts
@@ -354,8 +354,6 @@ export const getSubmissions = async (sheetId: string = TEST_SHEET_ID, useLocalTe
         }
 
         const firstLine = lines[0];
-        const actualSubmissionHeaders = ["Spotify URI", "Title", "Album", "Artist", "Submitter ID", "Created", "Comment", "Round ID", "Visible To Voters"];
-        const transformedCorrectHeaders = actualSubmissionHeaders.map(h => h.replace(/\s+/g, '').replace(/[()]/g, ''));
 
         const isProblematicFirstLine = firstLine.startsWith('"Spotify URI spotify:track:');
 


### PR DESCRIPTION
I removed the `transformedCorrectHeaders` variable in `src/services/googleSheets.ts` as it was assigned but never used, causing the CI build to fail.

Additionally, I removed the `actualSubmissionHeaders` variable in the same file, which became unused as a result of previous refactoring and was flagged by ESLint during the build verification process.

These changes ensure the build completes successfully without any unused variable warnings.