### PR TITLE
Refactor: Use flexible cards for rounds and competitors

### DIFF
--- a/src/components/CompetitorsView.scss
+++ b/src/components/CompetitorsView.scss
@@ -33,13 +33,17 @@
 }
 
 .competitor-list {
-  list-style-type: none;
   padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px; // Adds space between cards
 }
 
-.competitor-item {
+.competitor-card {
   border: 1px solid var(--medium-gray);
   padding: 12px 15px;
+  flex: 1 1 200px; // Flex properties for responsive cards
+  min-width: 200px; // Minimum width before wrapping
   margin-bottom: 10px;
   border-radius: 4px;
   background-color: var(--white);
@@ -51,7 +55,7 @@
     box-shadow: 0 2px 6px rgba(0,0,0,0.08);
   }
 
-  .competitor-item-name {
+  .competitor-item-name { // Keeping sub-element class names for now
     margin-top: 0;
     margin-bottom: 6px;
     font-size: 1.15em;
@@ -59,7 +63,7 @@
     font-weight: 500;
   }
 
-  .competitor-item-id {
+  .competitor-item-id { // Keeping sub-element class names for now
     margin-bottom: 0;
     font-size: 0.9em;
     color: var(--secondary-color);

--- a/src/components/CompetitorsView.tsx
+++ b/src/components/CompetitorsView.tsx
@@ -24,14 +24,14 @@ const CompetitorsView: React.FC<CompetitorsViewProps> = ({ competitors }) => {
   return (
     <div className="competitors-view-container">
       <h2>Competitors</h2>
-      <ul className="competitor-list">
+      <div className="competitor-list">
         {competitors.map((competitor) => (
-          <li key={competitor.ID} className="competitor-item">
+          <div key={competitor.ID} className="competitor-card">
             <h3 className="competitor-item-name">{competitor.Name || 'Unnamed Competitor'}</h3>
             <p className="competitor-item-id">ID: {competitor.ID}</p>
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };

--- a/src/components/RoundDetails.scss
+++ b/src/components/RoundDetails.scss
@@ -105,24 +105,34 @@
     color: var(--dark-gray);
   }
 
-  ul {
+  ul { // This will apply to any remaining ul, like the votes list
     list-style-type: none;
     padding-left: 0;
   }
 }
 
-// Submission Item
-.submission-item {
+// Styles for the new submission list container
+.submission-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 15px; // Space between cards
+  padding-left: 0; // Reset padding if any was inherited
+}
+
+// Submission Card (formerly Submission Item)
+.submission-card {
   border: 1px solid var(--medium-gray);
   padding: 15px;
-  margin-bottom: 15px;
-  display: flex;
+  // margin-bottom: 15px; // Gap handles this now
+  display: flex; // For internal layout of artwork and info
   align-items: flex-start;
   border-radius: 4px;
   background-color: var(--white);
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  flex: 1 1 300px; // Flex properties for responsive cards
+  min-width: 300px; // Minimum width before wrapping, adjust as needed
 
-  .submission-item-artwork {
+  .submission-item-artwork { // Class name kept for internal elements
     width: 100px;
     height: 100px;
     margin-right: 20px;
@@ -132,7 +142,7 @@
     border: 1px solid var(--medium-gray);
   }
 
-  .submission-item-info {
+  .submission-item-info { // Class name kept for internal elements
     flex-grow: 1;
 
     strong {

--- a/src/components/RoundDetails.tsx
+++ b/src/components/RoundDetails.tsx
@@ -166,7 +166,7 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
         <section className="submissions-section">
           <h3>Submissions ({currentRoundSubmissions.length})</h3>
           {currentRoundSubmissions.length === 0 && !isLoadingSpotifyData ? <p className="no-data-message">No submissions for this round.</p> : (
-            <ul>
+            <div className="submission-list"> {/* Changed ul to div and added a class */}
               {currentRoundSubmissions.map((sub) => {
                 const trackInfo = spotifyTrackDetails[sub.SpotifyURI];
                 const albumArtUrl = trackInfo?.image_url;
@@ -177,7 +177,7 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
                 );
 
                 return (
-                  <li key={sub.SpotifyURI + sub.SubmitterID} className="submission-item">
+                  <div key={sub.SpotifyURI + sub.SubmitterID} className="submission-card"> {/* Changed li to div and class name */}
                     {albumArtUrl && (
                       <img src={albumArtUrl} alt={sub.Album || 'Album art'} className="submission-item-artwork" />
                     )}
@@ -225,10 +225,10 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
                     {votesForThisSubmission.length === 0 && !isLoadingSpotifyData && (
                       <p className="no-votes-for-submission-message">No votes for this track yet.</p>
                     )}
-                  </li>
+                  </div>
                 );
               })}
-            </ul>
+            </div>
           )}
         </section>
 

--- a/src/components/RoundsList.scss
+++ b/src/components/RoundsList.scss
@@ -9,9 +9,15 @@
     text-align: left;
   }
 
-  ul {
-    list-style-type: none;
-    padding-left: 0;
+  // ul { // No longer directly styling ul here as it's replaced by div.rounds-card-list
+  //   list-style-type: none;
+  //   padding-left: 0;
+  // }
+  .rounds-card-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px; // Space between cards
+    padding-left: 0; // Remove any default padding
   }
 
   > p { // General messages like "No rounds found"
@@ -35,22 +41,24 @@
   text-align: left;
 }
 
-.rounds-list-item {
+.round-card { // Renamed from .rounds-list-item
   cursor: pointer;
-  margin-bottom: 12px;
+  // margin-bottom: 12px; // Replaced by gap in .rounds-card-list
   padding: 15px;
   border: 1px solid var(--medium-gray);
   background-color: var(--white);
   border-radius: 5px;
   transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
   text-align: left;
+  flex: 1 1 280px; // Flex properties for responsive cards
+  min-width: 280px; // Minimum width before wrapping
 
   &:hover {
     background-color: var(--light-gray);
     box-shadow: 0 3px 8px rgba(0,0,0,0.12);
   }
 
-  .rounds-list-item-name {
+  .rounds-list-item-name { // Keeping internal class names for now
     margin-top: 0;
     margin-bottom: 8px;
     font-size: 1.25em;

--- a/src/components/RoundsList.tsx
+++ b/src/components/RoundsList.tsx
@@ -90,14 +90,14 @@ const RoundsList: React.FC<RoundsListProps> = ({ sheetId, onRoundSelect, onRound
   return (
     <div className="rounds-list-container"> {/* Updated className */}
       <h2>Rounds</h2>
-      <ul>
+      <div className="rounds-card-list"> {/* Changed ul to div and added class */}
         {rounds.map((round) => (
           // Ensure round and round.ID are valid before rendering
           round && typeof round.ID !== 'undefined' ? (
-            <li
+            <div // Changed li to div
               key={round.ID}
               onClick={() => onRoundSelect(round.ID)}
-              className="rounds-list-item" // Added className
+              className="round-card" // Changed className
               // Removed inline styles and onMouseEnter/onMouseLeave
             >
               <h3 className="rounds-list-item-name">{round.Name || 'Unnamed Round'}</h3>
@@ -107,10 +107,10 @@ const RoundsList: React.FC<RoundsListProps> = ({ sheetId, onRoundSelect, onRound
                   <a href={round.PlaylistURL} target="_blank" rel="noopener noreferrer">Spotify Playlist</a>
                 </p>
               )}
-            </li>
+            </div>
           ) : null
         ))}
-      </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This commit refactors the display of rounds, competitors, and submissions to use a flexible card-based layout instead of rows. This change aims to improve the visual appeal and compatibility of the site by making better use of available space and providing a more modern look.

Changes include:
- Modified CompetitorsView, RoundDetails (for submissions), and RoundsList components to render items as cards.
- Updated corresponding SCSS files to style these cards using CSS Flexbox for responsiveness.
- Ensured that `npm install` and `npm run build` complete successfully after these changes.