### PR TITLE
feat: Update competitor cards to show points instead of IDs

### DIFF
--- a/src/components/CompetitorCard.tsx
+++ b/src/components/CompetitorCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Competitor } from '../types';
+
+interface CompetitorCardProps {
+  competitor: Competitor;
+  pointsLabel: string; // e.g., "Total Points:", "Cumulative Points:"
+}
+
+const CompetitorCard: React.FC<CompetitorCardProps> = ({ competitor, pointsLabel }) => {
+  return (
+    <div key={competitor.ID} className="competitor-card">
+      <h3 className="competitor-item-name">{competitor.Name || 'Unnamed Competitor'}</h3>
+      <p className="competitor-item-points">
+        {pointsLabel} {competitor.totalPoints !== undefined ? competitor.totalPoints : 0}
+      </p>
+    </div>
+  );
+};
+
+export default CompetitorCard;

--- a/src/components/CompetitorsView.tsx
+++ b/src/components/CompetitorsView.tsx
@@ -1,6 +1,7 @@
 // src/components/CompetitorsView.tsx
 import React from 'react';
 import { Competitor } from '../types';
+import CompetitorCard from './CompetitorCard'; // New import
 // Removed: import { getCompetitors } from '../services/googleSheets';
 import './CompetitorsView.scss'; // Import SCSS file
 
@@ -26,10 +27,7 @@ const CompetitorsView: React.FC<CompetitorsViewProps> = ({ competitors }) => {
       <h2>Competitors</h2>
       <div className="competitor-list">
         {competitors.map((competitor) => (
-          <div key={competitor.ID} className="competitor-card">
-            <h3 className="competitor-item-name">{competitor.Name || 'Unnamed Competitor'}</h3>
-            <p className="competitor-item-id">ID: {competitor.ID}</p>
-          </div>
+          <CompetitorCard key={competitor.ID} competitor={competitor} pointsLabel="Total Points:" />
         ))}
       </div>
     </div>

--- a/src/components/RoundDetails.tsx
+++ b/src/components/RoundDetails.tsx
@@ -4,6 +4,7 @@ import { Round, Submission, Vote, Competitor } from '../types'; // Added Competi
 // Removed: import { getSubmissions, getVotes } from '../services/googleSheets';
 import { fetchTrackDataFromBackend, SongData } from '../services/spotifyAPI';
 import VotesChart from './VotesChart';
+import CompetitorCard from './CompetitorCard'; // New import
 import './RoundDetails.scss'; // Import SCSS file
 
 interface RoundDetailsProps {
@@ -13,6 +14,7 @@ interface RoundDetailsProps {
   allSubmissions: Submission[];
   allVotes: Vote[];
   allCompetitors: Competitor[];
+  competitorsForRoundView: Competitor[]; // New: Competitors with points up to this round
 }
 
 const normalizeID = (id: string): string => {
@@ -25,6 +27,7 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
   allSubmissions,
   allVotes,
   allCompetitors,
+  competitorsForRoundView, // New prop
 }) => {
   const [currentRoundSubmissions, setCurrentRoundSubmissions] = useState<Submission[]>([]);
   const [currentRoundVotes, setCurrentRoundVotes] = useState<Vote[]>([]);
@@ -234,6 +237,20 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
 
         {/* The old standalone "Votes" section is now removed. */}
       </>
+
+      {/* New section for cumulative points of competitors up to this round */}
+      <section className="competitors-cumulative-points-section">
+        <h3>Standings (Up to {selectedRound.Name})</h3>
+        {competitorsForRoundView && competitorsForRoundView.length > 0 ? (
+          <div className="competitor-list"> {/* Can reuse 'competitor-list' class if styling is similar */}
+            {competitorsForRoundView.map((competitor) => (
+              <CompetitorCard key={competitor.ID} competitor={competitor} pointsLabel="Cumulative Points:" />
+            ))}
+          </div>
+        ) : (
+          <p>No competitor standings available for this round yet.</p>
+        )}
+      </section>
     </div>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface Round {
 export interface Competitor {
   ID: string;
   Name: string;
+  totalPoints?: number;
 }
 
 export interface Vote {

--- a/src/utils/pointUtils.ts
+++ b/src/utils/pointUtils.ts
@@ -1,0 +1,78 @@
+import { Competitor, Submission, Vote, Round } from '../types';
+
+export const calculateCumulativePoints = (
+  allCompetitors: Competitor[],
+  allSubmissions: Submission[],
+  allVotes: Vote[],
+  allRounds: Round[],
+  targetRoundId: string | null
+): Competitor[] => {
+  // 1. Create a deep copy of allCompetitors and initialize totalPoints
+  const competitorsWithPoints: Competitor[] = JSON.parse(JSON.stringify(allCompetitors));
+  competitorsWithPoints.forEach(c => {
+    if (c.totalPoints === undefined) {
+      c.totalPoints = 0;
+    }
+  });
+
+  // Create a map for quick lookup of competitors by ID
+  const competitorMap = new Map<string, Competitor>();
+  competitorsWithPoints.forEach(c => competitorMap.set(c.ID, c));
+
+  // 2. Create a map for quick lookup of submissions
+  const submissionOwnerMap = new Map<string, string>(); // Key: 'spotifyURI_roundID', Value: 'submitterID'
+  allSubmissions.forEach(sub => {
+    const key = sub.SpotifyURI + '_' + sub.RoundID;
+    submissionOwnerMap.set(key, sub.SubmitterID);
+  });
+
+  // 3. Determine the set of RoundIDs to consider
+  const relevantRoundIds = new Set<string>();
+
+  if (targetRoundId === null) {
+    // If targetRoundId is null, all rounds are relevant
+    allRounds.forEach(r => relevantRoundIds.add(r.ID));
+  } else {
+    // Sort rounds by creation time to establish a sequence
+    const sortedRounds = [...allRounds].sort((a, b) =>
+      new Date(a.Created).getTime() - new Date(b.Created).getTime()
+    );
+
+    const targetRoundIndex = sortedRounds.findIndex(r => r.ID === targetRoundId);
+
+    if (targetRoundIndex !== -1) {
+      // If targetRound is found, include all rounds up to and including it
+      for (let i = 0; i <= targetRoundIndex; i++) {
+        relevantRoundIds.add(sortedRounds[i].ID);
+      }
+    } else {
+      // If targetRoundId is specified but not found, include all rounds (permissive fallback)
+      allRounds.forEach(r => relevantRoundIds.add(r.ID));
+    }
+  }
+
+  // 4. Iterate through allVotes
+  allVotes.forEach(vote => {
+    // a. Check if vote.RoundID is one of the rounds to be included
+    if (!relevantRoundIds.has(vote.RoundID)) {
+      return; // Skip this vote
+    }
+
+    // b. Construct the key for submissionOwnerMap
+    const submissionKey = vote.SpotifyURI + '_' + vote.RoundID;
+    // c. Look up the submitterId
+    const submitterId = submissionOwnerMap.get(submissionKey);
+
+    if (submitterId) {
+      // d. Find the competitor
+      const competitor = competitorMap.get(submitterId);
+      if (competitor) {
+        // e. Add vote.PointsAssigned to their totalPoints
+        competitor.totalPoints = (competitor.totalPoints || 0) + vote.PointsAssigned;
+      }
+    }
+  });
+
+  // 5. Return the augmented list of competitors
+  return competitorsWithPoints;
+};


### PR DESCRIPTION
Refactors the display of competitor information across the application.

Key changes:
- Removed competitor IDs from being displayed on competitor cards.
- Competitor cards on the main view now show the total cumulative points for each competitor across all rounds.
- On round-specific details pages, competitor cards now show the cumulative points up to that particular round.
- Added a utility function `calculateCumulativePoints` to handle the logic for summing points, usable for both total and up-to-round calculations.
- Introduced a reusable `CompetitorCard.tsx` component to ensure consistent display of competitor information in both `CompetitorsView.tsx` and `RoundDetails.tsx`.
- Updated `types.ts` to include an optional `totalPoints` field in the `Competitor` interface.
- Modified `SheetDataViewer.tsx` to orchestrate point calculation and pass the augmented competitor data to the relevant components.

This change addresses the issue of removing IDs and provides a more meaningful points-based view of competitors in the league.