### PR TITLE
Fix: Update submission card style and artist processing

### DIFF
--- a/src/components/RoundDetails.scss
+++ b/src/components/RoundDetails.scss
@@ -129,6 +129,7 @@
   width: 100%; // Ensure it takes full width of its flex container part
   max-width: 700px; // Max width for readability
   display: flex; // For internal layout of artwork and info
+  flex-direction: column; // Stack children vertically
   align-items: flex-start;
   box-shadow: 0 1px 3px rgba(0,0,0,0.05); // Kept existing shadow
   flex: 1 1 300px; // Flex properties for responsive cards - this might conflict with width: 100% if parent is not flex.
@@ -146,8 +147,11 @@
   }
 
   .submission-item-info { // Class name kept for internal elements
-    flex-grow: 1;
-    margin-bottom: 15px; // Space between info and votes
+    // flex-grow: 1; // Removed as per request
+    width: 100%; // Ensure it takes full width in column layout
+    margin-bottom: 15px; // Space between info and potential next element
+    padding-bottom: 15px; // Space before the new border
+    border-bottom: 1px solid var(--medium-gray); // Visual separator
 
     strong {
       font-size: 1.15em;
@@ -211,9 +215,10 @@
 
   .submission-votes-section {
     width: 100%; // Ensure it takes full width within the card
-    margin-top: 15px;
-    border-top: 1px dashed #ccc; // Separator for votes section
-    padding-top: 10px;
+    margin-top: 0; // Adjusted because the separator is now on submission-item-info
+    // border-top: 1px dashed #ccc; // Removed, separator is now on submission-item-info's bottom
+    padding-top: 15px; // Adjusted padding
+    background-color: #f0f0f0; // Slightly different background
 
     .submission-votes-header {
       font-size: 1.1em;


### PR DESCRIPTION
This commit addresses several issues related to the submission display and data processing:

1.  **Submission Card Styling (`RoundDetails.scss`):**
    - Changed the main flex direction to column for `submission-card`.
    - Removed `flex-grow` from `submission-item-info` to prevent it from taking up unnecessary space, ensuring `width: 100%` for proper block layout.
    - Added a clear visual distinction between the submission information and the votes section using a bottom border on the info section and a background color on the votes section.

2.  **Artist(s) Field Processing (`googleSheets.ts`):**
    - Updated the header transformation logic within the `getSubmissions` function.
    - It now correctly maps the "Artist(s)" header (case-insensitive and ignoring spaces) from Google Sheets to the `Artist` field in the `Submission` type. This ensures that artist information is captured even if the header in the sheet is "Artist(s)".

3.  **Code Cleanup (`googleSheets.ts`):**
    - Removed obsolete code previously used to handle a specific malformed submissions tab scenario (related to `isProblematicFirstLine`). This simplifies the `getSubmissions` function and relies on the standard parsing logic.

4.  **Build Verification:**
    - Ran `npm install` and `npm run build` successfully, ensuring the project remains buildable after these changes.

These changes improve the visual presentation of submissions and the robustness of data handling from Google Sheets.