### PR TITLE
feat: Add sentiment-based backgrounds to vote comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,14 @@
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
         "sass": "^1.70.0",
+        "sentiment": "^5.0.2",
         "spotify-web-api-js": "^1.5.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/papaparse": "^5.3.16",
+        "@types/sentiment": "^5.0.4",
         "recharts": "^2.15.3"
       }
     },
@@ -3988,6 +3990,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sentiment": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sentiment/-/sentiment-5.0.4.tgz",
+      "integrity": "sha512-6FL0CYijhnrR3gHbu7boAJn8zRCekJXBPfIHLkIgWbkY+hz5Dwfsq79FM7l/tLZKuEgQWktnzf6JqV2UCWKrbg==",
+      "dev": true
     },
     "node_modules/@types/serve-index": {
       "version": "1.9.4",
@@ -14464,6 +14472,14 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/sentiment": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/sentiment/-/sentiment-5.0.2.tgz",
+      "integrity": "sha512-ZeC3y0JsOYTdwujt5uOd7ILJNilbgFzUtg/LEG4wUv43LayFNLZ28ec8+Su+h3saHlJmIwYxBzfDHHZuiMA15g==",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
     "sass": "^1.70.0",
+    "sentiment": "^5.0.2",
     "spotify-web-api-js": "^1.5.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/papaparse": "^5.3.16",
+    "@types/sentiment": "^5.0.4",
     "recharts": "^2.15.3"
   }
 }

--- a/src/components/RoundDetails.scss
+++ b/src/components/RoundDetails.scss
@@ -241,17 +241,27 @@
       padding-left: 0;
 
       .submission-vote-item {
-        padding: 8px 0;
+        padding: 8px 10px; // Added some horizontal padding
         border-bottom: 1px solid #eee; // Separator for each vote
+        color: #212529; // Dark text color for contrast
 
         &:last-child {
           border-bottom: none;
         }
 
+        p, strong, em, span, div { // Target common text-holding elements and divs (like ExpandableText root)
+          color: inherit !important; // Ensure they use the parent's color, overriding specifics if necessary
+          font-size: 1em; // Standardize font size unless specifically overridden by nested styles
+        }
+
         p {
-          margin: 3px 0; // Compact spacing for vote lines
-          em { // For the ExpandableText in votes
-            font-size: 1em; // Reset from parent .submission-item-info em if needed, or inherit
+          margin: 4px 0; // Adjusted margin for better spacing with background
+          strong {
+            font-weight: 600; // Ensure voter name is bold
+          }
+          em {
+            font-style: italic; // Ensure comment text is italic
+            // font-size is inherited from p
           }
         }
       }

--- a/src/components/RoundDetails.tsx
+++ b/src/components/RoundDetails.tsx
@@ -1,5 +1,6 @@
 // src/components/RoundDetails.tsx
 import React, { useState, useEffect, useMemo } from 'react';
+import { getSentimentScore, getSentimentColor } from '../utils/sentimentUtils';
 import { Round, Submission, Vote, Competitor } from '../types';
 import { fetchTrackDataFromBackend, SongData } from '../services/spotifyAPI';
 import VotesChart from './VotesChart';
@@ -249,8 +250,17 @@ const RoundDetails: React.FC<RoundDetailsProps> = ({
                         <ul className="submission-votes-list">
                           {sortedVotesForThisSubmission.map((vote, voteIndex) => {
                             const voterName = getVoterName(vote.VoterID);
+                            let backgroundColor = '';
+                            if (vote.Comment) {
+                              const score = getSentimentScore(vote.Comment);
+                              backgroundColor = getSentimentColor(score);
+                            }
                             return (
-                              <li key={`${vote.VoterID}-${vote.SpotifyURI}-${voteIndex}`} className="submission-vote-item">
+                              <li
+                                key={`${vote.VoterID}-${vote.SpotifyURI}-${voteIndex}`}
+                                className="submission-vote-item"
+                                style={{ backgroundColor }}
+                              >
                                 <p><strong>{voterName}</strong> (+{vote.PointsAssigned})</p>
                                 {vote.Comment && <p><em><ExpandableText text={vote.Comment} maxLength={100} /></em></p>}
                               </li>

--- a/src/utils/sentimentUtils.test.ts
+++ b/src/utils/sentimentUtils.test.ts
@@ -1,0 +1,115 @@
+import { getSentimentScore, getSentimentColor } from './sentimentUtils';
+
+describe('sentimentUtils', () => {
+  describe('getSentimentScore', () => {
+    it('should return a positive score for a positive string', () => {
+      const score = getSentimentScore("This is great! I love it.");
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThanOrEqual(1);
+    });
+
+    it('should return a negative score for a negative string', () => {
+      const score = getSentimentScore("This is terrible, I hate it.");
+      expect(score).toBeLessThan(0);
+      expect(score).toBeGreaterThanOrEqual(-1);
+    });
+
+    it('should return a score close to 0 for a neutral string', () => {
+      // Note: "neutral" can be tricky. Sentiment libraries might still assign a slight score.
+      // We'll check if it's within a small range around 0.
+      // "This is a statement." -> AFINN assigns 0.
+      const score = getSentimentScore("This is a statement.");
+      // For this library, a truly neutral statement often results in 0.
+      // If it were more complex, we might use: expect(score).toBeCloseTo(0, 1);
+      // For "This is a statement.", the sentiment library gives a score of 0.
+      // analysis.score is 0. 0 / 5 = 0.
+      expect(score).toEqual(0);
+    });
+
+    it('should return 0 for an empty string', () => {
+      expect(getSentimentScore("")).toBe(0);
+    });
+
+    it('should return 0 for a string with only whitespace', () => {
+      expect(getSentimentScore("   ")).toBe(0);
+    });
+
+    it('should clamp a very positive score to 1', () => {
+      // "excellent fantastic wonderful amazing superb" has a raw score of 2+3+4+4+3 = 16
+      // 16/5 = 3.2, which should be clamped to 1
+      const score = getSentimentScore("excellent fantastic wonderful amazing superb joy triumph happy");
+      expect(score).toBe(1);
+    });
+
+    it('should clamp a very negative score to -1', () => {
+      // "awful dreadful horrible terrible vile" has a raw score of -3-3-3-3-3 = -15
+      // -15/5 = -3, which should be clamped to -1
+      const score = getSentimentScore("awful dreadful horrible terrible vile doom gloom sad");
+      expect(score).toBe(-1);
+    });
+  });
+
+  describe('getSentimentColor', () => {
+    const NEUTRAL_COLOR = 'hsl(0, 0%, 95%)';
+
+    it('should return green-like for score 1', () => {
+      expect(getSentimentColor(1)).toBe('hsl(120, 100%, 85%)');
+    });
+
+    it('should return red-like for score -1', () => {
+      expect(getSentimentColor(-1)).toBe('hsl(0, 100%, 85%)');
+    });
+
+    it('should return neutral for score 0', () => {
+      expect(getSentimentColor(0)).toBe(NEUTRAL_COLOR);
+    });
+
+    it('should return neutral for score 0.05 (at positive threshold)', () => {
+      expect(getSentimentColor(0.05)).toBe(NEUTRAL_COLOR);
+    });
+
+    it('should return neutral for score -0.05 (at negative threshold)', () => {
+      expect(getSentimentColor(-0.05)).toBe(NEUTRAL_COLOR);
+    });
+
+    it('should return yellowish-green for score 0.5', () => {
+      // hue = 60 + (60 * 0.5) = 60 + 30 = 90
+      expect(getSentimentColor(0.5)).toBe('hsl(90, 100%, 85%)');
+    });
+
+    it('should return orange-like for score -0.5', () => {
+      // hue = 60 * (1 + (-0.5)) = 60 * 0.5 = 30
+      expect(getSentimentColor(-0.5)).toBe('hsl(30, 100%, 85%)');
+    });
+
+    it('should return positive color for score 0.06 (just above positive threshold)', () => {
+      const color = getSentimentColor(0.06);
+      expect(color).not.toBe(NEUTRAL_COLOR);
+      // hue = 60 + (60 * 0.06) = 60 + 3.6 = 63.6
+      expect(color).toBe('hsl(63.6, 100%, 85%)');
+    });
+
+    it('should return negative color for score -0.06 (just below negative threshold)', () => {
+      const color = getSentimentColor(-0.06);
+      expect(color).not.toBe(NEUTRAL_COLOR);
+      // hue = 60 * (1 + (-0.06)) = 60 * 0.94 = 56.4
+      expect(color).toBe('hsl(56.4, 100%, 85%)');
+    });
+
+    it('should return neutral color for score 0.04 (just below positive threshold)', () => {
+      expect(getSentimentColor(0.04)).toBe(NEUTRAL_COLOR);
+    });
+
+    it('should return neutral color for score -0.04 (just above negative threshold)', () => {
+      expect(getSentimentColor(-0.04)).toBe(NEUTRAL_COLOR);
+    });
+
+    it('should clamp scores greater than 1 for color calculation', () => {
+      expect(getSentimentColor(1.5)).toBe('hsl(120, 100%, 85%)');
+    });
+
+    it('should clamp scores less than -1 for color calculation', () => {
+      expect(getSentimentColor(-1.5)).toBe('hsl(0, 100%, 85%)');
+    });
+  });
+});

--- a/src/utils/sentimentUtils.ts
+++ b/src/utils/sentimentUtils.ts
@@ -1,0 +1,51 @@
+import Sentiment from 'sentiment';
+
+/**
+ * Calculates a sentiment score for a given text.
+ * The score ranges from -1 (very negative) to 1 (very positive).
+ *
+ * @param text The input string to analyze.
+ * @returns A sentiment score between -1 and 1, or 0 if the text is empty/whitespace.
+ */
+export function getSentimentScore(text: string): number {
+  if (!text || text.trim() === '') {
+    return 0;
+  }
+
+  const sentiment = new Sentiment();
+  const analysis = sentiment.analyze(text);
+
+  // Normalize the raw score. The library's typical effective range for 'score'
+  // is often within -5 to +5. Dividing by 5 is a reasonable normalization strategy.
+  const normalizedScore = analysis.score / 5;
+
+  // Clamp the result to be within -1 and 1 to handle potential outliers.
+  return Math.max(-1, Math.min(1, normalizedScore));
+}
+
+/**
+ * Determines a background color based on a sentiment score.
+ * The score is expected to be between -1 (very negative) and 1 (very positive).
+ *
+ * @param score The sentiment score.
+ * @returns An HSL color string for negative/positive scores, or a light gray for neutral.
+ */
+export function getSentimentColor(score: number): string {
+  // Clamp the score to ensure it's within the expected -1 to 1 range.
+  const clampedScore = Math.max(-1, Math.min(1, score));
+
+  if (clampedScore < -0.05) {
+    // Negative sentiment: Interpolate hue from red (0) towards yellow (60)
+    // As score goes from -1 to 0: hue = 60 * (1 + score)
+    const hue = 60 * (1 + clampedScore);
+    return `hsl(${hue}, 100%, 85%)`;
+  } else if (clampedScore > 0.05) {
+    // Positive sentiment: Interpolate hue from yellow (60) towards green (120)
+    // As score goes from 0 to 1: hue = 60 + (60 * score)
+    const hue = 60 + 60 * clampedScore;
+    return `hsl(${hue}, 100%, 85%)`;
+  } else {
+    // Neutral sentiment: Return a light gray
+    return 'hsl(0, 0%, 95%)';
+  }
+}


### PR DESCRIPTION
This feature implements dynamic background colors for vote comments based on their calculated sentiment.

Key changes:
- Added the 'sentiment' library for natural language sentiment analysis.
- Created `src/utils/sentimentUtils.ts` with two main functions:
    - `getSentimentScore(text: string)`: Analyzes comment text and returns a normalized score between -1 (negative) and 1 (positive).
    - `getSentimentColor(score: number)`: Maps the sentiment score to an HSL background color, ranging from red (negative) through yellow (neutral) to green (positive).
- Integrated these utilities into `src/components/RoundDetails.tsx`:
    - Vote comments now have their background color dynamically set based on their sentiment score.
- Updated `src/components/RoundDetails.scss` to ensure text within comments remains legible with the new backgrounds.
- Added comprehensive unit tests for `sentimentUtils.ts` to verify the correctness of scoring and color mapping logic. All tests pass.

This provides you with a quick visual cue about the nature of comments on submissions.